### PR TITLE
Add option to preserve code backticks

### DIFF
--- a/CODE_DOCUMENTATION.md
+++ b/CODE_DOCUMENTATION.md
@@ -70,7 +70,7 @@ All settings are registered in `settings.ts` via `registerPluginSettings()`. Set
 
 All default to `false` unless noted.
 
-- Preservation toggles: `preserveSuperscript`, `preserveSubscript`, `preserveEmphasis`, `preserveBold`, `preserveHeading`, `preserveStrikethrough`, `preserveHorizontalRule`, `preserveMark`, `preserveInsert`, `preserveTablePipes`.
+- Preservation toggles: `preserveSuperscript`, `preserveSubscript`, `preserveEmphasis`, `preserveBold`, `preserveHeading`, `preserveStrikethrough`, `preserveHorizontalRule`, `preserveMark`, `preserveInsert`, `preserveCodeBackticks`, `preserveTablePipes`.
 - `displayEmojis` (default `true`): convert `:emoji:` syntax to Unicode.
 - `hyperlinkBehavior`: emit external links as `title`, `url`, or `markdown`.
 - `indentType`: choose list indentation via spaces or tabs.

--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ The following options are provided to preserve specific markdown formatting mark
 
 - Preserve insert markers
 
+- Preserve code backticks
+
 - Preserve table pipes
 
 The following options are provided for external hyperlinks (only affects markdown links with `http`/`https` URLs):

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -20,6 +20,7 @@ export const SETTINGS = {
     PRESERVE_HORIZONTAL_RULE: 'preserveHorizontalRule',
     PRESERVE_MARK: 'preserveMark',
     PRESERVE_INSERT: 'preserveInsert',
+    PRESERVE_CODE_BACKTICKS: 'preserveCodeBackticks',
     DISPLAY_EMOJIS: 'displayEmojis',
     HYPERLINK_BEHAVIOR: 'hyperlinkBehavior',
     INDENT_TYPE: 'indentType',

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -106,6 +106,12 @@
             "description": "If enabled, insert markers will be preserved in plain text output.",
             "value": false
         },
+        "preserveCodeBackticks": {
+            "type": "bool",
+            "label": "Preserve code backticks",
+            "description": "If enabled, inline code and code block backticks will be preserved in plain text output.",
+            "value": false
+        },
         "hyperlinkBehavior": {
             "type": "enum",
             "label": "Plain text hyperlink behavior",

--- a/src/plainText/plainTextRenderer.test.ts
+++ b/src/plainText/plainTextRenderer.test.ts
@@ -177,6 +177,36 @@ describe('List rendering', () => {
 4. **Range computation helper**:`;
         expect(result.trimEnd()).toBe(expected);
     });
+
+    it('should add a blank line before code blocks within list items when list spacing is loose (preserveCodeBackticks disabled)', () => {
+        const markdown = `3. **\`buildColorTheme\`** - emit per-type rules:
+
+   \`\`\`typescript
+   rules[\`.cm-gh-alert-\${type}\`] = {
+       '--cm-gh-alert-color': color,
+       '--cm-gh-alert-bg': bg,
+   };
+   return EditorView.theme(rules);
+   \`\`\`
+
+4. **Range computation helper**:`;
+        const result = convertMarkdownToPlainText(markdown, {
+            ...defaultOptions,
+            listSpacing: 'loose',
+            preserveBold: true,
+            preserveCodeBackticks: false,
+        });
+        const expected = `3. **buildColorTheme** - emit per-type rules:
+
+    rules[\`.cm-gh-alert-\${type}\`] = {
+        '--cm-gh-alert-color': color,
+        '--cm-gh-alert-bg': bg,
+    };
+    return EditorView.theme(rules);
+
+4. **Range computation helper**:`;
+        expect(result.trimEnd()).toBe(expected);
+    });
 });
 
 // Character preservation tests

--- a/src/plainText/plainTextRenderer.test.ts
+++ b/src/plainText/plainTextRenderer.test.ts
@@ -15,6 +15,7 @@ const defaultOptions: PlainTextOptions = {
     preserveHorizontalRule: false,
     preserveMark: false,
     preserveInsert: false,
+    preserveCodeBackticks: false,
     displayEmojis: true,
     hyperlinkBehavior: 'title',
     indentType: 'spaces',
@@ -407,6 +408,18 @@ describe('Code Block Handling', () => {
         expect(result.trim()).toBe('Use `backticks` for inline code.');
     });
 
+    it('should preserve inline code backticks when enabled', () => {
+        const markdown = 'Use the `console.log()` function to debug.';
+        const result = convertMarkdownToPlainText(markdown, { ...defaultOptions, preserveCodeBackticks: true });
+        expect(result.trim()).toBe('Use the `console.log()` function to debug.');
+    });
+
+    it('should preserve nested inline code backticks when enabled', () => {
+        const markdown = 'Use `` `backticks` `` for inline code.';
+        const result = convertMarkdownToPlainText(markdown, { ...defaultOptions, preserveCodeBackticks: true });
+        expect(result.trim()).toBe('Use `` `backticks` `` for inline code.');
+    });
+
     it('should remove fence markers but preserve content', () => {
         const markdown = `\`\`\`typescript
 function test() {
@@ -418,6 +431,19 @@ function test() {
     return "hello";
 }`;
         expect(result.trim()).toBe(expected);
+    });
+
+    it('should preserve fenced code block backticks when enabled', () => {
+        const markdown = '```javascript\nconst x = 1;\nconsole.log(x);\n```';
+        const result = convertMarkdownToPlainText(markdown, { ...defaultOptions, preserveCodeBackticks: true });
+        const expected = '```javascript\nconst x = 1;\nconsole.log(x);\n```';
+        expect(result.trim()).toBe(expected);
+    });
+
+    it('should use a longer code block fence when the content contains triple backticks', () => {
+        const markdown = '````\n```nested fence```\n````';
+        const result = convertMarkdownToPlainText(markdown, { ...defaultOptions, preserveCodeBackticks: true });
+        expect(result.trim()).toBe('````\n```nested fence```\n````');
     });
 });
 

--- a/src/plainText/plainTextRenderer.test.ts
+++ b/src/plainText/plainTextRenderer.test.ts
@@ -145,6 +145,38 @@ describe('List rendering', () => {
 4. Then, take a backup of your LIVE database. To do this, go to the Companies tab and highlight your LIVE Company and click Backup As. Choose where to save/what to name the backup (it will be a .DAT file).`;
         expect(result.trimEnd()).toBe(expected);
     });
+
+    it('should add a blank line before code blocks within list items when list spacing is loose', () => {
+        const markdown = `3. **\`buildColorTheme\`** - emit per-type rules:
+
+   \`\`\`typescript
+   rules[\`.cm-gh-alert-\${type}\`] = {
+       '--cm-gh-alert-color': color,
+       '--cm-gh-alert-bg': bg,
+   };
+   return EditorView.theme(rules);
+   \`\`\`
+
+4. **Range computation helper**:`;
+        const result = convertMarkdownToPlainText(markdown, {
+            ...defaultOptions,
+            listSpacing: 'loose',
+            preserveBold: true,
+            preserveCodeBackticks: true,
+        });
+        const expected = `3. **\`buildColorTheme\`** - emit per-type rules:
+
+    \`\`\`typescript
+    rules[\`.cm-gh-alert-\${type}\`] = {
+        '--cm-gh-alert-color': color,
+        '--cm-gh-alert-bg': bg,
+    };
+    return EditorView.theme(rules);
+    \`\`\`
+
+4. **Range computation helper**:`;
+        expect(result.trimEnd()).toBe(expected);
+    });
 });
 
 // Character preservation tests

--- a/src/plainText/plainTextRenderer.ts
+++ b/src/plainText/plainTextRenderer.ts
@@ -123,6 +123,11 @@ function renderInlineWithMarkers(
     return preserve ? `${marker}${text}${marker}` : text;
 }
 
+/**
+ * Returns a backtick fence string long enough to wrap `text` without ambiguity.
+ * The fence must be strictly longer than any consecutive backtick run inside the
+ * content, and at least `minimumLength` characters (1 for inline code, 3 for blocks).
+ */
 function backtickFenceFor(text: string, minimumLength: number): string {
     const runs = text.match(/`+/g) ?? [];
     const longestRun = runs.reduce((max, run) => Math.max(max, run.length), 0);

--- a/src/plainText/plainTextRenderer.ts
+++ b/src/plainText/plainTextRenderer.ts
@@ -30,6 +30,7 @@ type PlainTextNode = {
     ordered?: boolean;
     start?: number;
     checked?: boolean | null;
+    lang?: string | null;
     children?: PlainTextNode[];
 };
 
@@ -122,12 +123,35 @@ function renderInlineWithMarkers(
     return preserve ? `${marker}${text}${marker}` : text;
 }
 
+function backtickFenceFor(text: string, minimumLength: number): string {
+    const runs = text.match(/`+/g) ?? [];
+    const longestRun = runs.reduce((max, run) => Math.max(max, run.length), 0);
+    return '`'.repeat(Math.max(minimumLength, longestRun + 1));
+}
+
+function renderInlineCode(value: string, options: PlainTextOptions): string {
+    if (!options.preserveCodeBackticks) return value;
+
+    const fence = backtickFenceFor(value, 1);
+    const padding = value.startsWith('`') || value.endsWith('`') ? ' ' : '';
+    return `${fence}${padding}${value}${padding}${fence}`;
+}
+
+function renderCodeBlock(node: PlainTextNode, options: PlainTextOptions): string {
+    const value = (node.value ?? '').replace(/\n+$/g, '');
+    if (!options.preserveCodeBackticks) return value;
+
+    const fence = backtickFenceFor(value, 3);
+    const lang = node.lang ?? '';
+    return `${fence}${lang}\n${value}\n${fence}`;
+}
+
 function renderInlineNode(node: PlainTextNode, options: PlainTextOptions): string {
     switch (node.type) {
         case 'text':
             return unescapeMarkdownText((node.value ?? '').replace(PLAIN_TEXT_REGEX.FOOTNOTE_REF, '[$1]'));
         case 'inlineCode':
-            return node.value ?? '';
+            return renderInlineCode(node.value ?? '', options);
         case 'break':
             return '\n';
         case 'html':
@@ -281,7 +305,7 @@ function renderBlockNode(node: PlainTextNode, options: PlainTextOptions, depth =
         case 'blockquote':
             return renderBlocks(node.children ?? [], options, depth).trim();
         case 'code':
-            return (node.value ?? '').replace(/\n+$/g, '');
+            return renderCodeBlock(node, options);
         case 'html':
             return htmlFragmentToPlainText(node.value ?? '');
         case 'thematicBreak':

--- a/src/plainText/plainTextRenderer.ts
+++ b/src/plainText/plainTextRenderer.ts
@@ -205,16 +205,11 @@ function renderListItemContent(node: PlainTextNode, options: PlainTextOptions, d
             continue;
         }
 
-        if (
-            options.listSpacing === 'loose' &&
-            child.type === 'list' &&
-            lines.length > 0 &&
-            lines[lines.length - 1] !== ''
-        ) {
+        const block = renderBlockNode(child, options, child.type === 'list' ? depth : depth + 1);
+        if (options.listSpacing === 'loose' && block && lines.length > 0 && lines[lines.length - 1] !== '') {
             lines.push('');
         }
 
-        const block = renderBlockNode(child, options, child.type === 'list' ? depth : depth + 1);
         if (block) lines.push(...block.split('\n'));
     }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -140,6 +140,15 @@ export async function registerPluginSettings(): Promise<void> {
             label: 'Preserve insert markers',
             description: 'If enabled, insert markers will be preserved in plain text output.',
         },
+        [SETTINGS.PRESERVE_CODE_BACKTICKS]: {
+            value: false,
+            type: SettingItemType.Bool,
+            section: SECTION_ID,
+            public: true,
+            advanced: true,
+            label: 'Preserve code backticks',
+            description: 'If enabled, inline code and code block backticks will be preserved in plain text output.',
+        },
         [SETTINGS.HYPERLINK_BEHAVIOR]: {
             value: 'title',
             type: SettingItemType.String,
@@ -228,6 +237,7 @@ export async function loadPlainTextSettings(): Promise<PlainTextOptions> {
         preserveHorizontalRule: await joplin.settings.value(SETTINGS.PRESERVE_HORIZONTAL_RULE),
         preserveMark: await joplin.settings.value(SETTINGS.PRESERVE_MARK),
         preserveInsert: await joplin.settings.value(SETTINGS.PRESERVE_INSERT),
+        preserveCodeBackticks: await joplin.settings.value(SETTINGS.PRESERVE_CODE_BACKTICKS),
         displayEmojis: await joplin.settings.value(SETTINGS.DISPLAY_EMOJIS),
         hyperlinkBehavior: await joplin.settings.value(SETTINGS.HYPERLINK_BEHAVIOR),
         indentType: await joplin.settings.value(SETTINGS.INDENT_TYPE),

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,7 @@ export interface PlainTextOptions {
     preserveHorizontalRule: boolean;
     preserveMark: boolean;
     preserveInsert: boolean;
+    preserveCodeBackticks: boolean;
     displayEmojis: boolean;
     hyperlinkBehavior: 'title' | 'url' | 'markdown';
     indentType: 'spaces' | 'tabs';

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -32,6 +32,7 @@ describe('validatePlainTextSettings', () => {
             indentType: 123, // not a string
             listSpacing: 'wide',
             preserveTablePipes: 'yes',
+            preserveCodeBackticks: 'yes',
         };
 
         const validated = validatePlainTextSettings(invalidSettings);
@@ -41,6 +42,7 @@ describe('validatePlainTextSettings', () => {
         expect(validated.indentType).toBe('spaces');
         expect(validated.listSpacing).toBe('tight');
         expect(validated.preserveTablePipes).toBe(false);
+        expect(validated.preserveCodeBackticks).toBe(false);
     });
 
     it('should return default values for undefined or null settings', () => {
@@ -51,6 +53,7 @@ describe('validatePlainTextSettings', () => {
         expect(validatedUndefined.listSpacing).toBe('tight');
         expect(validatedUndefined.displayEmojis).toBe(true);
         expect(validatedUndefined.preserveTablePipes).toBe(false);
+        expect(validatedUndefined.preserveCodeBackticks).toBe(false);
 
         const validatedNull = validatePlainTextSettings(null);
         expect(validatedNull.preserveSuperscript).toBe(false);
@@ -59,6 +62,7 @@ describe('validatePlainTextSettings', () => {
         expect(validatedNull.listSpacing).toBe('tight');
         expect(validatedNull.displayEmojis).toBe(true);
         expect(validatedNull.preserveTablePipes).toBe(false);
+        expect(validatedNull.preserveCodeBackticks).toBe(false);
     });
 });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -31,6 +31,7 @@ export function validatePlainTextSettings(settings: unknown): PlainTextOptions {
         preserveHorizontalRule: validateBooleanSetting(s.preserveHorizontalRule),
         preserveMark: validateBooleanSetting(s.preserveMark),
         preserveInsert: validateBooleanSetting(s.preserveInsert),
+        preserveCodeBackticks: validateBooleanSetting(s.preserveCodeBackticks),
         displayEmojis: validateBooleanSetting(s.displayEmojis, true), // Default to true
         // Only accept a string value and one of the allowed options.
         hyperlinkBehavior:


### PR DESCRIPTION
Introduce a setting to retain inline and block code backticks in plain text output. Fix spacing issues with indented fenced code in lists by ensuring a blank line appears before rendered nested blocks within list items.