### PR TITLE
feat: Remove GitHub alert syntax and add quote marker preservation option

### DIFF
--- a/CODE_DOCUMENTATION.md
+++ b/CODE_DOCUMENTATION.md
@@ -70,7 +70,7 @@ All settings are registered in `settings.ts` via `registerPluginSettings()`. Set
 
 All default to `false` unless noted.
 
-- Preservation toggles: `preserveSuperscript`, `preserveSubscript`, `preserveEmphasis`, `preserveBold`, `preserveHeading`, `preserveStrikethrough`, `preserveHorizontalRule`, `preserveMark`, `preserveInsert`, `preserveCodeBackticks`, `preserveTablePipes`.
+- Preservation toggles: `preserveSuperscript`, `preserveSubscript`, `preserveEmphasis`, `preserveBold`, `preserveHeading`, `preserveQuoteMarkers`, `preserveStrikethrough`, `preserveHorizontalRule`, `preserveMark`, `preserveInsert`, `preserveCodeBackticks`, `preserveTablePipes`.
 - `displayEmojis` (default `true`): convert `:emoji:` syntax to Unicode.
 - `hyperlinkBehavior`: emit external links as `title`, `url`, or `markdown`.
 - `indentType`: choose list indentation via spaces or tabs.

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ The following options are provided to preserve specific markdown formatting mark
 
 - Preserve heading markers
 
+- Preserve quote markers
+
 - Preserve strikethrough markers
 
 - Preserve horizontal rules

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -48,6 +48,9 @@ export const HTML_CONSTANTS = {
 
 export const RESOURCE_ID_REGEX = /^[a-f0-9]{32}$/i;
 
+// Matches a GitHub/Joplin alert marker only at the start of blockquote content.
+export const GITHUB_ALERT_MARKER_REGEX = /^\s*\[![^\]\r\n]+\](?:[ \t]*\r?\n|[ \t]*)/i;
+
 // Plain text renderer specific (values not already in CONSTANTS)
 export const PLAIN_TEXT_CONSTANTS = {
     ORDERED_LIST_START: 1,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,6 +16,7 @@ export const SETTINGS = {
     PRESERVE_EMPHASIS: 'preserveEmphasis',
     PRESERVE_BOLD: 'preserveBold',
     PRESERVE_HEADING: 'preserveHeading',
+    PRESERVE_QUOTE_MARKERS: 'preserveQuoteMarkers',
     PRESERVE_STRIKETHROUGH: 'preserveStrikethrough',
     PRESERVE_HORIZONTAL_RULE: 'preserveHorizontalRule',
     PRESERVE_MARK: 'preserveMark',
@@ -55,6 +56,7 @@ export const GITHUB_ALERT_MARKER_REGEX = /^\s*\[![^\]\r\n]+\](?:[ \t]*\r?\n|[ \t
 export const PLAIN_TEXT_CONSTANTS = {
     ORDERED_LIST_START: 1,
     BULLET_PREFIX: '- ',
+    BLOCKQUOTE_PREFIX: '>',
     ORDERED_SUFFIX: '. ',
     HEADING_PREFIX_CHAR: '#',
     HORIZONTAL_RULE_MARKER: '---',

--- a/src/html/domPostProcess.test.ts
+++ b/src/html/domPostProcess.test.ts
@@ -122,6 +122,30 @@ describe('domPostProcess', () => {
         expect(out).toContain('Resource');
     });
 
+    it('removes marker-only GitHub alert syntax from blockquotes', async () => {
+        const html = '<blockquote><p>[!note]<br>Test abc</p></blockquote>';
+        const out = await postProcessHtml(html);
+
+        expect(out).toContain('<blockquote><p>Test abc</p></blockquote>');
+        expect(out).not.toContain('[!note]');
+    });
+
+    it('keeps GitHub alert titles as blockquote content', async () => {
+        const html = '<blockquote><p>[!note] title<br>Test abc</p></blockquote>';
+        const out = await postProcessHtml(html);
+
+        expect(out).toContain('<blockquote><p>title<br>Test abc</p></blockquote>');
+        expect(out).not.toContain('[!note]');
+    });
+
+    it('removes extended GitHub alert types from blockquotes', async () => {
+        const html = '<blockquote><p>[!example] Extended title<br>Test abc</p></blockquote>';
+        const out = await postProcessHtml(html);
+
+        expect(out).toContain('<blockquote><p>Extended title<br>Test abc</p></blockquote>');
+        expect(out).not.toContain('[!example]');
+    });
+
     it('wraps top-level raw HTML images in separate paragraph blocks', async () => {
         const html = '<img src="https://x/a.png" alt="a">\n\n<img src="https://x/b.png" alt="b">';
         const out = await postProcessHtml(html, {

--- a/src/html/domPostProcess.ts
+++ b/src/html/domPostProcess.ts
@@ -284,6 +284,13 @@ function wrapTopLevelImages(doc: Document): void {
         });
 }
 
+/**
+ * Depth-first search for the first non-whitespace text node within `node`.
+ * Used to locate the start of a blockquote's content (e.g. an alert marker),
+ * skipping over wrapper elements and empty/whitespace-only text nodes.
+ * @param node - Root node to search under.
+ * @returns The first meaningful Text node, or null if none exists.
+ */
 function findFirstTextNode(node: Node): Text | null {
     for (const child of Array.from(node.childNodes)) {
         if (child.nodeType === 3 && child.textContent?.trim()) {
@@ -299,6 +306,12 @@ function findFirstTextNode(node: Node): Text | null {
     return null;
 }
 
+/**
+ * Removes leading whitespace-only text nodes and `<br>` elements from `element`.
+ * Run after stripping an alert marker so the residual blank line / line break it
+ * left behind does not appear in the rendered blockquote.
+ * @param element - Element whose leading empty nodes should be trimmed.
+ */
 function removeLeadingEmptyNodes(element: Element): void {
     while (element.firstChild) {
         const first = element.firstChild;
@@ -311,6 +324,12 @@ function removeLeadingEmptyNodes(element: Element): void {
     }
 }
 
+/**
+ * Removes `element` when it is a now-empty `<p>` left behind by marker stripping.
+ * Skips removal if the paragraph still holds visible text or embedded content
+ * (images, inputs, tables, lists, or code) that has no text representation.
+ * @param element - Candidate paragraph to remove.
+ */
 function removeIfEmptyParagraph(element: Element): void {
     if (element.tagName !== 'P') return;
     if (element.textContent?.trim()) return;
@@ -319,6 +338,13 @@ function removeIfEmptyParagraph(element: Element): void {
     element.remove();
 }
 
+/**
+ * Strips a leading GitHub/Joplin alert marker (e.g. `[!note]`) from the start of
+ * each blockquote's content, keeping any trailing title text. Cleans up the empty
+ * text node and line break the marker leaves behind, and drops the wrapping
+ * paragraph if it becomes empty.
+ * @param doc - Document to process in place.
+ */
 function stripGithubAlertMarkers(doc: Document): void {
     doc.querySelectorAll('blockquote').forEach((blockquote) => {
         const firstText = findFirstTextNode(blockquote);

--- a/src/html/domPostProcess.ts
+++ b/src/html/domPostProcess.ts
@@ -1,5 +1,5 @@
 import DOMPurify from 'dompurify';
-import { HTML_CONSTANTS } from '../constants';
+import { GITHUB_ALERT_MARKER_REGEX, HTML_CONSTANTS } from '../constants';
 import { logger } from '../logger';
 import { convertResourceToBase64, downloadRemoteImageAsBase64 } from './assetProcessor';
 
@@ -284,6 +284,59 @@ function wrapTopLevelImages(doc: Document): void {
         });
 }
 
+function findFirstTextNode(node: Node): Text | null {
+    for (const child of Array.from(node.childNodes)) {
+        if (child.nodeType === 3 && child.textContent?.trim()) {
+            return child as Text;
+        }
+
+        if (child.nodeType === 1) {
+            const textNode = findFirstTextNode(child);
+            if (textNode) return textNode;
+        }
+    }
+
+    return null;
+}
+
+function removeLeadingEmptyNodes(element: Element): void {
+    while (element.firstChild) {
+        const first = element.firstChild;
+        const isEmptyText = first.nodeType === 3 && !first.textContent?.trim();
+        const isLineBreak = first.nodeType === 1 && (first as Element).tagName === 'BR';
+
+        if (!isEmptyText && !isLineBreak) break;
+
+        first.remove();
+    }
+}
+
+function removeIfEmptyParagraph(element: Element): void {
+    if (element.tagName !== 'P') return;
+    if (element.textContent?.trim()) return;
+    if (element.querySelector('img,input,table,ul,ol,pre,code')) return;
+
+    element.remove();
+}
+
+function stripGithubAlertMarkers(doc: Document): void {
+    doc.querySelectorAll('blockquote').forEach((blockquote) => {
+        const firstText = findFirstTextNode(blockquote);
+        if (!firstText?.textContent) return;
+
+        const strippedText = firstText.textContent.replace(GITHUB_ALERT_MARKER_REGEX, '');
+        if (strippedText === firstText.textContent) return;
+
+        firstText.textContent = strippedText;
+
+        const parentElement = firstText.parentElement;
+        if (!parentElement) return;
+
+        removeLeadingEmptyNodes(parentElement);
+        removeIfEmptyParagraph(parentElement);
+    });
+}
+
 /**
  * Checks if an element should skip rasterization (e.g., inside code blocks).
  * @param node - Element to check
@@ -457,12 +510,13 @@ interface PostProcessOptions {
  * 1. Sanitize HTML with DOMPurify (removes scripts, dangerous attributes)
  * 2. Remove duplicate joplin-source elements from code blocks
  * 3. Replace broken resource placeholders with error messages
- * 4. Remove non-image Joplin resource links (:/... or joplin://resource/...)
- * 5. Strip Joplin images if embedding is disabled
- * 6. Embed images (local and remote) as base64 if enabled
- * 7. Disable checkbox inputs
- * 8. Wrap top-level images in paragraph tags for consistent formatting
- * 9. Convert SVG data URIs to PNG (requires Canvas API)
+ * 4. Strip GitHub alert markers from blockquote content
+ * 5. Remove non-image Joplin resource links (:/... or joplin://resource/...)
+ * 6. Strip Joplin images if embedding is disabled
+ * 7. Embed images (local and remote) as base64 if enabled
+ * 8. Disable checkbox inputs
+ * 9. Wrap top-level images in paragraph tags for consistent formatting
+ * 10. Convert SVG data URIs to PNG (requires Canvas API)
  */
 export async function postProcessHtml(
     html: string,
@@ -481,6 +535,7 @@ export async function postProcessHtml(
     // Pipeline of transformations
     removeJoplinSourceElements(doc);
     replaceBrokenResourceSpans(doc);
+    stripGithubAlertMarkers(doc);
     stripJoplinLinks(doc);
     disableCheckboxes(doc);
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -82,6 +82,12 @@
             "description": "If enabled, heading markers will be preserved in plain text output.",
             "value": false
         },
+        "preserveQuoteMarkers": {
+            "type": "bool",
+            "label": "Preserve quote markers",
+            "description": "If enabled, blockquote markers will be preserved in plain text output.",
+            "value": false
+        },
         "preserveStrikethrough": {
             "type": "bool",
             "label": "Preserve strikethrough markers",

--- a/src/plainText/plainTextRenderer.test.ts
+++ b/src/plainText/plainTextRenderer.test.ts
@@ -322,6 +322,32 @@ describe('Complex Structures and Edge Cases', () => {
         expect(result.trim()).toBe('This is a quote.');
     });
 
+    it('should remove marker-only GitHub alert syntax from blockquotes', () => {
+        const markdown = `> [!note]
+> Test abc`;
+        const result = convertMarkdownToPlainText(markdown, defaultOptions);
+
+        expect(result.trim()).toBe('Test abc');
+    });
+
+    it('should keep GitHub alert titles as blockquote content', () => {
+        const markdown = `> [!note] title
+> Test abc`;
+        const result = convertMarkdownToPlainText(markdown, defaultOptions);
+
+        expect(result.trim()).toBe(`title
+Test abc`);
+    });
+
+    it('should remove extended GitHub alert types from blockquotes', () => {
+        const markdown = `> [!example] Extended title
+> Test abc`;
+        const result = convertMarkdownToPlainText(markdown, defaultOptions);
+
+        expect(result.trim()).toBe(`Extended title
+Test abc`);
+    });
+
     it('should handle nested blockquotes', () => {
         const markdown = `
 > Level 1

--- a/src/plainText/plainTextRenderer.test.ts
+++ b/src/plainText/plainTextRenderer.test.ts
@@ -11,6 +11,7 @@ const defaultOptions: PlainTextOptions = {
     preserveEmphasis: false,
     preserveBold: false,
     preserveHeading: false,
+    preserveQuoteMarkers: false,
     preserveStrikethrough: false,
     preserveHorizontalRule: false,
     preserveMark: false,
@@ -216,6 +217,7 @@ describe('Character Preservation Options', () => {
         ['preserveHeading', '## This is a heading', '## This is a heading', 'This is a heading'],
         ['preserveBold', '**This is bold text**', '**This is bold text**', 'This is bold text'],
         ['preserveEmphasis', '*This is emphasis text*', '*This is emphasis text*', 'This is emphasis text'],
+        ['preserveQuoteMarkers', '> This is a quote.', '> This is a quote.', 'This is a quote.'],
         ['preserveStrikethrough', '~~deleted text~~', '~~deleted text~~', 'deleted text'],
         ['preserveHorizontalRule', '---', '---', '\u00A0'],
         ['preserveMark', '==highlighted text==', '==highlighted text==', 'highlighted text'],
@@ -362,6 +364,46 @@ Test abc`);
 Level 2
 
 Back to Level 1`;
+        expect(result.trim()).toBe(expected);
+    });
+
+    it('should preserve quote markers when enabled', () => {
+        const markdown = `> First line
+>
+> Second line`;
+        const result = convertMarkdownToPlainText(markdown, { ...defaultOptions, preserveQuoteMarkers: true });
+        const expected = `> First line
+>
+> Second line`;
+
+        expect(result.trim()).toBe(expected);
+    });
+
+    it('should preserve nested quote markers when enabled', () => {
+        const markdown = `
+> Level 1
+>
+> > Level 2
+>
+> Back to Level 1
+`;
+        const result = convertMarkdownToPlainText(markdown, { ...defaultOptions, preserveQuoteMarkers: true });
+        const expected = `> Level 1
+>
+> > Level 2
+>
+> Back to Level 1`;
+
+        expect(result.trim()).toBe(expected);
+    });
+
+    it('should remove GitHub alert syntax while preserving quote markers', () => {
+        const markdown = `> [!example] Extended title
+> Test abc`;
+        const result = convertMarkdownToPlainText(markdown, { ...defaultOptions, preserveQuoteMarkers: true });
+        const expected = `> Extended title
+> Test abc`;
+
         expect(result.trim()).toBe(expected);
     });
 

--- a/src/plainText/plainTextRenderer.ts
+++ b/src/plainText/plainTextRenderer.ts
@@ -75,6 +75,12 @@ function walkTextNodes(node: PlainTextNode, visitor: (node: PlainTextNode) => vo
     }
 }
 
+/**
+ * Depth-first search for the first text node within an mdast `node`.
+ * Used to locate the start of a blockquote's content (e.g. an alert marker).
+ * @param node - Root node to search under.
+ * @returns The first text node, or null if none exists.
+ */
 function findFirstTextNode(node: PlainTextNode): PlainTextNode | null {
     if (node.type === 'text') return node;
 
@@ -86,6 +92,12 @@ function findFirstTextNode(node: PlainTextNode): PlainTextNode | null {
     return null;
 }
 
+/**
+ * Strips a leading GitHub/Joplin alert marker (e.g. `[!note]`) from the start of
+ * a blockquote's first text node, mutating it in place. Any trailing title text
+ * is preserved.
+ * @param node - Blockquote node to process.
+ */
 function stripGithubAlertMarkerFromBlockquote(node: PlainTextNode): void {
     const firstText = findFirstTextNode(node);
     if (!firstText?.value) return;
@@ -93,6 +105,13 @@ function stripGithubAlertMarkerFromBlockquote(node: PlainTextNode): void {
     firstText.value = firstText.value.replace(GITHUB_ALERT_MARKER_REGEX, '');
 }
 
+/**
+ * Re-applies blockquote markers to already-rendered text, prefixing each line
+ * with `> ` (or a bare `>` for blank lines). Used when `preserveQuoteMarkers`
+ * is enabled so the plain-text output keeps its quote structure.
+ * @param text - Rendered blockquote body.
+ * @returns The body with every line quote-prefixed.
+ */
 function prefixBlockquoteLines(text: string): string {
     return text
         .split('\n')

--- a/src/plainText/plainTextRenderer.ts
+++ b/src/plainText/plainTextRenderer.ts
@@ -93,6 +93,15 @@ function stripGithubAlertMarkerFromBlockquote(node: PlainTextNode): void {
     firstText.value = firstText.value.replace(GITHUB_ALERT_MARKER_REGEX, '');
 }
 
+function prefixBlockquoteLines(text: string): string {
+    return text
+        .split('\n')
+        .map((line) =>
+            line ? `${PLAIN_TEXT_CONSTANTS.BLOCKQUOTE_PREFIX} ${line}` : PLAIN_TEXT_CONSTANTS.BLOCKQUOTE_PREFIX
+        )
+        .join('\n');
+}
+
 function htmlFragmentToPlainText(html: string): string {
     if (!html) return '';
     if (!domParser) {
@@ -320,9 +329,12 @@ function renderBlockNode(node: PlainTextNode, options: PlainTextOptions, depth =
             const level = Math.min(Math.max(node.depth ?? 1, 1), 6);
             return `${PLAIN_TEXT_CONSTANTS.HEADING_PREFIX_CHAR.repeat(level)} ${text}`.trim();
         }
-        case 'blockquote':
+        case 'blockquote': {
             stripGithubAlertMarkerFromBlockquote(node);
-            return renderBlocks(node.children ?? [], options, depth).trim();
+            const quoteBody = renderBlocks(node.children ?? [], options, depth).trim();
+            if (!quoteBody) return '';
+            return options.preserveQuoteMarkers ? prefixBlockquoteLines(quoteBody) : quoteBody;
+        }
         case 'code':
             return renderCodeBlock(node, options);
         case 'html':

--- a/src/plainText/plainTextRenderer.ts
+++ b/src/plainText/plainTextRenderer.ts
@@ -16,7 +16,7 @@ import remarkParse from 'remark-parse';
 import remarkSupersub from 'remark-supersub';
 import { unified } from 'unified';
 import type { Plugin } from 'unified';
-import { PLAIN_TEXT_CONSTANTS, PLAIN_TEXT_REGEX } from '../constants';
+import { GITHUB_ALERT_MARKER_REGEX, PLAIN_TEXT_CONSTANTS, PLAIN_TEXT_REGEX } from '../constants';
 import { logger } from '../logger';
 import type { PlainTextOptions } from '../types';
 
@@ -73,6 +73,24 @@ function walkTextNodes(node: PlainTextNode, visitor: (node: PlainTextNode) => vo
     for (const child of node.children ?? []) {
         walkTextNodes(child, visitor);
     }
+}
+
+function findFirstTextNode(node: PlainTextNode): PlainTextNode | null {
+    if (node.type === 'text') return node;
+
+    for (const child of node.children ?? []) {
+        const textNode = findFirstTextNode(child);
+        if (textNode) return textNode;
+    }
+
+    return null;
+}
+
+function stripGithubAlertMarkerFromBlockquote(node: PlainTextNode): void {
+    const firstText = findFirstTextNode(node);
+    if (!firstText?.value) return;
+
+    firstText.value = firstText.value.replace(GITHUB_ALERT_MARKER_REGEX, '');
 }
 
 function htmlFragmentToPlainText(html: string): string {
@@ -303,6 +321,7 @@ function renderBlockNode(node: PlainTextNode, options: PlainTextOptions, depth =
             return `${PLAIN_TEXT_CONSTANTS.HEADING_PREFIX_CHAR.repeat(level)} ${text}`.trim();
         }
         case 'blockquote':
+            stripGithubAlertMarkerFromBlockquote(node);
             return renderBlocks(node.children ?? [], options, depth).trim();
         case 'code':
             return renderCodeBlock(node, options);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -104,6 +104,15 @@ export async function registerPluginSettings(): Promise<void> {
             label: 'Preserve heading markers',
             description: 'If enabled, heading markers will be preserved in plain text output.',
         },
+        [SETTINGS.PRESERVE_QUOTE_MARKERS]: {
+            value: false,
+            type: SettingItemType.Bool,
+            section: SECTION_ID,
+            public: true,
+            advanced: true,
+            label: 'Preserve quote markers',
+            description: 'If enabled, blockquote markers will be preserved in plain text output.',
+        },
         [SETTINGS.PRESERVE_STRIKETHROUGH]: {
             value: false,
             type: SettingItemType.Bool,
@@ -233,6 +242,7 @@ export async function loadPlainTextSettings(): Promise<PlainTextOptions> {
         preserveEmphasis: await joplin.settings.value(SETTINGS.PRESERVE_EMPHASIS),
         preserveBold: await joplin.settings.value(SETTINGS.PRESERVE_BOLD),
         preserveHeading: await joplin.settings.value(SETTINGS.PRESERVE_HEADING),
+        preserveQuoteMarkers: await joplin.settings.value(SETTINGS.PRESERVE_QUOTE_MARKERS),
         preserveStrikethrough: await joplin.settings.value(SETTINGS.PRESERVE_STRIKETHROUGH),
         preserveHorizontalRule: await joplin.settings.value(SETTINGS.PRESERVE_HORIZONTAL_RULE),
         preserveMark: await joplin.settings.value(SETTINGS.PRESERVE_MARK),

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,7 @@ export interface PlainTextOptions {
     preserveEmphasis: boolean;
     preserveBold: boolean;
     preserveHeading: boolean;
+    preserveQuoteMarkers: boolean;
     preserveStrikethrough: boolean;
     preserveHorizontalRule: boolean;
     preserveMark: boolean;

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -33,6 +33,7 @@ describe('validatePlainTextSettings', () => {
             listSpacing: 'wide',
             preserveTablePipes: 'yes',
             preserveCodeBackticks: 'yes',
+            preserveQuoteMarkers: 'yes',
         };
 
         const validated = validatePlainTextSettings(invalidSettings);
@@ -43,6 +44,7 @@ describe('validatePlainTextSettings', () => {
         expect(validated.listSpacing).toBe('tight');
         expect(validated.preserveTablePipes).toBe(false);
         expect(validated.preserveCodeBackticks).toBe(false);
+        expect(validated.preserveQuoteMarkers).toBe(false);
     });
 
     it('should return default values for undefined or null settings', () => {
@@ -54,6 +56,7 @@ describe('validatePlainTextSettings', () => {
         expect(validatedUndefined.displayEmojis).toBe(true);
         expect(validatedUndefined.preserveTablePipes).toBe(false);
         expect(validatedUndefined.preserveCodeBackticks).toBe(false);
+        expect(validatedUndefined.preserveQuoteMarkers).toBe(false);
 
         const validatedNull = validatePlainTextSettings(null);
         expect(validatedNull.preserveSuperscript).toBe(false);
@@ -63,6 +66,7 @@ describe('validatePlainTextSettings', () => {
         expect(validatedNull.displayEmojis).toBe(true);
         expect(validatedNull.preserveTablePipes).toBe(false);
         expect(validatedNull.preserveCodeBackticks).toBe(false);
+        expect(validatedNull.preserveQuoteMarkers).toBe(false);
     });
 });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -27,6 +27,7 @@ export function validatePlainTextSettings(settings: unknown): PlainTextOptions {
         preserveEmphasis: validateBooleanSetting(s.preserveEmphasis),
         preserveBold: validateBooleanSetting(s.preserveBold),
         preserveHeading: validateBooleanSetting(s.preserveHeading),
+        preserveQuoteMarkers: validateBooleanSetting(s.preserveQuoteMarkers),
         preserveStrikethrough: validateBooleanSetting(s.preserveStrikethrough),
         preserveHorizontalRule: validateBooleanSetting(s.preserveHorizontalRule),
         preserveMark: validateBooleanSetting(s.preserveMark),


### PR DESCRIPTION
Eliminate GitHub alert syntax from HTML and plaintext outputs to enhance readability. Introduce an option to preserve quote markers in plaintext output.